### PR TITLE
[PR-623] Explicitly set password to no expire for SSH users

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,11 @@
   with_items: "{{ users_add_users }}"
   when: users_add_users
 
+- name: Set password policy to never expire
+  shell: "chage -I -1 -m 0 -M 99999 -E -1 {{ item.username }}"
+  with_items: "{{ users_add_users }}"
+  when: users_add_users
+
 - name: Set permissions on home directory (CIS Benchmark 6.2.8)
   file:
     path: "{{ item.home|default('/home/'+item.username) }}"

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -24,5 +24,12 @@
       - comment:  "devops group privileges"
         spec:     "%devops ALL=(ALL) NOPASSWD: ALL"
 
+  pre_tasks:
+    - name: change default password expiry for new accounts to check it is correctly set when applying role
+      lineinfile:
+        path: /etc/login.defs
+        regexp: '^PASS_MAX_DAYS'
+        line: PASS_MAX_DAYS 30
+
   roles:
     - ansible-users

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -9,6 +9,8 @@ describe user('ogonna') do
   it { should have_home_directory '/home/ogonna' }
   it { should have_login_shell '/bin/bash' }
   it { should have_authorized_key ssh_key_ogonna }
+  its(:maximum_days_between_password_change) { should eq 99999 }
+  its(:minimum_days_between_password_change) { should eq 0 }
 end
 
 describe user('adaku') do


### PR DESCRIPTION
Since CIS security changes, a default password policy of 90 days was being set for new users. This ensures any users created via Ansible don't have a password expiry. 

Password authentication is never enabled but when a password expires it interferes with SSH key-based authentication: https://unix.stackexchange.com/questions/160268/expired-password-and-ssh-key-based-login-with-usepam-yes